### PR TITLE
supress GCC template argument warnings (-Wno-ignored-attributes)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC"
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
   endif()
 elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-long-long -fstrict-aliasing")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-long-long -Wno-ignored-attributes -fstrict-aliasing")
 endif ()
 
 ## REFERENCE TO MAIN PROJECT

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 𝒂𝒓𝒌a𝒏𝒂
 ======
 
-Somthing of an fs infra library (Intel AVX2 accelerated) for C++17
+Something of an fs infra library (Intel AVX2 accelerated) for C++17
 
 ---
 


### PR DESCRIPTION
Compiling arkana with GCC 10.2.1 results in over 300 lines of ``warning: ignoring attributes on template argument`` in the build output.

Sample:
```
In file included from arkana/arkana/arkana/camellia/./camellia-avx2.h:14,
                 from arkana/arkana/arkana/camellia/camellia-avx2.cpp:12:
arkana/arkana/arkana/camellia/./../ark/xmm.h:170:89: warning: ignoring attributes on template argument '__m128i' [-Wignored-attributes]
  170 |         template <class XMM> using is_xmm = std::is_same<typename XMM::vector_t, __m128i>;
      |                                                                                         ^
arkana/arkana/arkana/camellia/./../ark/xmm.h:171:89: warning: ignoring attributes on template argument '__m128i' [-Wignored-attributes]
  171 |         template <class YMM> using is_ymm = std::is_same<typename YMM::vector_t, __m128i>;
      |                                                                                         ^
arkana/arkana/arkana/camellia/./../ark/xmm.h:172:106: warning: ignoring attributes on template argument '__m128i' [-Wignored-attributes]
  172 |         template <class NMM> using is_nmm = std::disjunction<std::is_same<typename NMM::vector_t, __m128i>, std::is_same<typename NMM::vector_t, __m256i>>;
      |                  
```

The warnings can be suppressed with ``-Wno-ignored-attributes``
